### PR TITLE
[BC-31] deploy: fix scp source paths in deployment workflow

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -53,9 +53,7 @@ jobs:
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
           port: ${{ secrets.EC2_PORT }}
-          source: |
-            docker-compose.yml
-            nginx
+          source: "docker-compose.yml,nginx"
           target: ${{ steps.vars.outputs.TARGET_DIR }}
           overwrite: true
 


### PR DESCRIPTION
## Changes
- 서버로 파일을 복사하는 과정에서 발생한 오류를 수정합니다.