### PR TITLE
[BC-31] deploy: enable https redirect and ssl for nginx

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -24,6 +24,18 @@ http {
         listen 80;
         server_name bandchu.o-r.kr;
 
+        return 301 https://$host$request_uri;
+    }
+
+    server {
+        listen 443 ssl http2;
+        server_name bandchu.o-r.kr;
+
+        ssl_certificate     /etc/nginx/certs/fullchain.pem;
+        ssl_certificate_key /etc/nginx/certs/privkey.pem;
+        ssl_protocols       TLSv1.2 TLSv1.3;
+        ssl_ciphers         HIGH:!aNULL:!MD5;
+
         location /health {
             return 200 'ok';
             add_header Content-Type text/plain;


### PR DESCRIPTION
## Changes
- Nginx 설정에 HTTPS 리다이렉트 적용
- SSL 인증서 경로 추가 및 HTTPS 서버 블록 구성
- HTTP(80) 요청을 HTTPS로 자동 리다이렉트하도록 설정