### PR TITLE
feat(concert): add description, genre to subscribed artist dto

### DIFF
--- a/src/main/kotlin/com/bandchu/api/domain/concert/dto/ConcertMapper.kt
+++ b/src/main/kotlin/com/bandchu/api/domain/concert/dto/ConcertMapper.kt
@@ -67,6 +67,8 @@ fun List<ConcertSubscribedRead>.toConcertSubscribedResponse(): ConcertSubscribed
         SubscribedArtistDto(
             artistId = readModel.artists.id,
             name = readModel.artists.artistName,
+            description = readModel.artists.description,
+            genre = readModel.artists.genre.map { it.name },
             profileImageUrl = readModel.artists.profileImageUrl,
             subscribedAt = readModel.subscribedAt.toString(),
             concerts = concertResponses

--- a/src/main/kotlin/com/bandchu/api/domain/concert/dto/SubscribedArtistDto.kt
+++ b/src/main/kotlin/com/bandchu/api/domain/concert/dto/SubscribedArtistDto.kt
@@ -5,6 +5,8 @@ import java.net.URI
 data class SubscribedArtistDto(
     val artistId: Long,
     val name: String,
+    val description: String?,
+    val genre: List<String>,
     val profileImageUrl: URI?,
     val subscribedAt: String,
     val concerts: List<SubscribedConcertDto>


### PR DESCRIPTION
- 캘린더 화면을 구성하기 위해, 필드를 추가했습니다.
- 기존에 사용하던 구독 목록 조회 데이터 대신 구독한 공연 목록 조회에서 받아온 데이터를 사용합니다.