### PR TITLE
fix(S3): add _CREDENTIAL_ on application.yml

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,6 +30,6 @@ aws:
   s3:
     bucket: bandchu-bucket
   credentials:
-    accessKey: ${AWS_ACCESS_KEY}
-    secretKey: ${AWS_SECRET_KEY}
+    accessKey: ${AWS_CREDENTIAL_ACCESS_KEY}
+    secretKey: ${AWS_CREDENTIAL_SECRET_KEY}
     client-id: ${GOOGLE_CLIENT_ID}


### PR DESCRIPTION
S3의 키값을 배포 서버에서 읽지 못하는 문제를 해결하기 위해, 스프링 부트 프로젝트의  application.yml 파일을 수정하여 배포합니다.