### PR TITLE
deploy: add cors configuration to filter chain

### DIFF
--- a/src/main/kotlin/com/bandchu/api/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/bandchu/api/global/config/SecurityConfig.kt
@@ -36,6 +36,7 @@ class SecurityConfig(
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
         http
+            .cors {}
             .csrf { it.disable() }
             .sessionManagement { session ->
                 session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)


### PR DESCRIPTION
- `/subscriptions` 등 특정 경로에서만 CORS 오류가 발생하고 있는 상황입니다.
- 스프링 시큐리티 필터 체인에 누락된 CORS 설정을 적용합니다.
- 추가로, 일부를 제외한 전체 경로에 대해 인증이 진행되고 있지 않으므로 추후 수정이 필요합니다.